### PR TITLE
Add queries for browser type

### DIFF
--- a/src/Components/Header/_Header.scss
+++ b/src/Components/Header/_Header.scss
@@ -12,7 +12,19 @@ header {
   color: white;
   cursor: pointer;
   font-size: 1.3em;
-  margin-left: 80%;
+  margin-left: 40%;
   position: fixed;
   z-index: 100;
+}
+
+@media screen and (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm) {
+   .link {
+    margin-left: 80%;
+  }
+}
+
+@supports (-webkit-touch-callout: none) {
+  .link {
+   margin-left: 40%;
+ }
 }


### PR DESCRIPTION
### What does this PR do? 
This branch should fix the issue with the FAQ element not appearing on iPhones. It sets the `margin-left` to 40% by default, then adds a query that targets chrome browsers and sets the value to 80%. Lastly it targets iphone browsers specifically and sets the value back to 40%, this might not be necessary- chrome on iOS should trip the chrome styling- but it's a safeguard just in case. 

### Is this a feature or Fix/Refactor?  
Fix

### Problems Encountered & Resulting Solutions  
This entire bug was a Problem Encountered to be sure. The solution here was to enable web development on my phone, hook it up to safari on my machine, and start messing with the styling. After that it was just a bit of trail and error to find the right media queries. 

### Where should the reviewer start?
Read through the changes to `_Header.scss`

### This PR is related to which issues:
closes #65 
